### PR TITLE
Adicionando validação no endpoint `/eval`

### DIFF
--- a/maas/calc/app.py
+++ b/maas/calc/app.py
@@ -11,5 +11,29 @@ async def calc(request: web.Request):
     expr = (await request.json())["expr"]
     parser = Tree()
     parser.parse(expr)
-    result = await parser.root.eval()
-    return web.json_response({"result": result})
+
+    try:
+        parser.evaluate()
+    except Exception as e:
+        return web.json_response(
+            {
+                "result": None,
+                "error": {"exc": str(e), "reason": "Invalid Expression"},
+            },
+            status=400,
+        )
+
+    try:
+        result = await parser.root.eval()
+        return web.json_response({"result": result})
+    except Exception as e:
+        return web.json_response(
+            {
+                "result": None,
+                "error": {
+                    "exc": str(e),
+                    "reason": "Error evaluating expression",
+                },
+            },
+            status=500,
+        )


### PR DESCRIPTION
Fazemos duas validações.

 - Uma para verificar se a expressão foi parseada com sucesso
 - Outra para detectar algunm erro na chamada aos demais micro-serviços